### PR TITLE
Separation of bins images, new colors

### DIFF
--- a/src/proc_image_processing/cpu/filters/detectors/sift_calculator.h
+++ b/src/proc_image_processing/cpu/filters/detectors/sift_calculator.h
@@ -59,7 +59,7 @@ namespace proc_image_processing {
             std::vector<std::vector<cv::KeyPoint>> keypoints;
 
             std::vector<std::string> list_paths({"G-Man","Bootlegger", "Badge",
-            "Gun","Notepad","Whiskey","Axe","Dollar"}); //HARDCODED
+            "Gun","Barrel","Whiskey","Phone","Notepad","Axe","Dollar"}); //HARDCODED
             
             for(int i = 0; i< list_paths.size(); i++){
                 std::string complete_path = kRefImagesPath + list_paths[i] + kImagesExt;

--- a/src/proc_image_processing/cpu/filters/detectors/sift_match.h
+++ b/src/proc_image_processing/cpu/filters/detectors/sift_match.h
@@ -162,13 +162,17 @@ namespace proc_image_processing {
                 case 3: // Collecting
                     temp_ref_descriptors.push_back(ref_descriptors[4]);
                     temp_ref_descriptors.push_back(ref_descriptors[5]);
-                    matching_points_list = create_matcher_list(temp_ref_descriptors, im_descriptors, im_keypoints);
-                    colors.push_back(WHITE); //"collecting_gman_white" WHITE
-                    colors.push_back(GRAY); //"collecting_bootlegger_white" GRAY
-                    break;
-                case 4: // Cash Shmash
                     temp_ref_descriptors.push_back(ref_descriptors[6]);
                     temp_ref_descriptors.push_back(ref_descriptors[7]);
+                    matching_points_list = create_matcher_list(temp_ref_descriptors, im_descriptors, im_keypoints);
+                    colors.push_back(PURPLE); //Barrel
+                    colors.push_back(GRAY); //Whiskey
+                    colors.push_back(CYAN);//Phone 
+                    colors.push_back(WHITE);//Notepad
+                    break;
+                case 4: // Cash Shmash
+                    temp_ref_descriptors.push_back(ref_descriptors[8]);
+                    temp_ref_descriptors.push_back(ref_descriptors[9]);
                     matching_points_list = create_matcher_list(temp_ref_descriptors, im_descriptors, im_keypoints);
                     colors.push_back(ORANGE); //"cashSmash_axe_orange" ORANGE
                     colors.push_back(GREEN); //"cashSmash_dollar_orange" GREEN
@@ -179,8 +183,10 @@ namespace proc_image_processing {
                     colors.push_back(BLUE); //"bootlegger" BLUE
                     colors.push_back(YELLOW); //"badge" YELLOW
                     colors.push_back(BLUE); // "fusil"
-                    colors.push_back(WHITE); //"collecting_gman_white" WHITE
-                    colors.push_back(GRAY); //"collecting_bootlegger_white" GRAY
+                    colors.push_back(PURPLE); //Barrel
+                    colors.push_back(GRAY); //Whiskey
+                    colors.push_back(CYAN);//Phone 
+                    colors.push_back(WHITE);//Notepad
                     colors.push_back(ORANGE); //"cashSmash_axe_orange" ORANGE
                     colors.push_back(GREEN); //"cashSmash_dollar_orange" GREEN
 
@@ -404,6 +410,7 @@ namespace proc_image_processing {
             ref_descriptors.push_back(temp_descriptor);
 
             //Load keypoints
+            //Not used
             std::vector<cv::KeyPoint> temp_kp;
             fsRead[list_paths[i]+"_kp"] >> temp_kp;
             ref_keypoints.push_back(temp_kp);


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Images in the bins :barrel/whiskey and notepad/phones were respectively two images before. Now they are split to be one image each so a total of four. Colors were added to differentiate each. This was done to have a better alignemnet with the bins.

## Fixes
Link all the related issues from the issue tracker
- Closes #

## How has this been tested ?
On simulation only with a look on the rostopic to verifiy the names of the images detected.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings